### PR TITLE
Un notebook pour automatiser le lancement de tests en fonction de différents paramètress

### DIFF
--- a/framework_pipeline_test.ipynb
+++ b/framework_pipeline_test.ipynb
@@ -1,0 +1,313 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "collapsed_sections": [
+        "BxaanZoIKZRg"
+      ],
+      "authorship_tag": "ABX9TyMJmSyyFNro750WquvdIFaJ",
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/SocialGouv/srdt/blob/framework_pipeline_test/framework_pipeline_test.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Chargement des fonctions depuis google drive"
+      ],
+      "metadata": {
+        "id": "BxaanZoIKZRg"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Monter google drive dans Google colab\n",
+        "from google.colab import drive\n",
+        "drive.mount('/content/drive')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "fuGabxc7KDBt",
+        "outputId": "5d3f2017-26db-4aa1-ce67-25a948d36616"
+      },
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Drive already mounted at /content/drive; to attempt to forcibly remount, call drive.mount(\"/content/drive\", force_remount=True).\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import os\n",
+        "os.chdir('/content/drive/My Drive/srdt_analysis')\n",
+        "import sys\n",
+        "sys.path.append('/content/drive/MyDrive/srdt_analysis')\n",
+        "from instructions_LLM import instructions\n",
+        "from framework_test_functions import call_LLM, albert_search, pipeline_test_RAG"
+      ],
+      "metadata": {
+        "id": "USFAYP81KVcZ"
+      },
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "nCoxypg5d-Gm"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Chargement des fonctions depuis github"
+      ],
+      "metadata": {
+        "id": "DpXTStITKV4I"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!wget https://raw.githubusercontent.com/SocialGouv/srdt/refs/heads/framework_pipeline_test/srdt_analysis/framework_test_functions.py\n",
+        "!wget https://raw.githubusercontent.com/SocialGouv/srdt/refs/heads/framework_pipeline_test/srdt_analysis/instructions_LLM.py\n",
+        "!wget https://raw.githubusercontent.com/SocialGouv/srdt/refs/heads/framework_pipeline_test/srdt_analysis/API_KEYS.py\n",
+        "\n",
+        "#remarque : si la PR change de branche, il faut aussi changer les URLs (ici elles sont dans la branche \"framework_pipeline_test\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "tzhshsV5F0n5",
+        "outputId": "6c1d674b-d647-4cf8-d811-0929547ae006"
+      },
+      "execution_count": 32,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "--2024-12-09 18:15:12--  https://raw.githubusercontent.com/SocialGouv/srdt/refs/heads/remi/srdt_analysis/framework_test_functions.py\n",
+            "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.108.133, 185.199.109.133, 185.199.110.133, ...\n",
+            "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... connected.\n",
+            "HTTP request sent, awaiting response... 404 Not Found\n",
+            "2024-12-09 18:15:12 ERROR 404: Not Found.\n",
+            "\n",
+            "--2024-12-09 18:15:12--  https://raw.githubusercontent.com/SocialGouv/srdt/refs/heads/remi/srdt_analysis/instructions_LLM.py\n",
+            "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.111.133, 185.199.109.133, 185.199.110.133, ...\n",
+            "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.111.133|:443... connected.\n",
+            "HTTP request sent, awaiting response... 404 Not Found\n",
+            "2024-12-09 18:15:12 ERROR 404: Not Found.\n",
+            "\n",
+            "--2024-12-09 18:15:13--  https://raw.githubusercontent.com/SocialGouv/srdt/refs/heads/remi/srdt_analysis/API_KEYS.py\n",
+            "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.108.133, 185.199.111.133, 185.199.110.133, ...\n",
+            "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... connected.\n",
+            "HTTP request sent, awaiting response... 404 Not Found\n",
+            "2024-12-09 18:15:13 ERROR 404: Not Found.\n",
+            "\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from instructions_LLM import instructions\n",
+        "from framework_test_functions import call_LLM, albert_search, pipeline_test_RAG"
+      ],
+      "metadata": {
+        "id": "QVRtkuYZGmuG"
+      },
+      "execution_count": 39,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "M2b1lCP6NnON"
+      },
+      "execution_count": 8,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Réglage des paramètres de test"
+      ],
+      "metadata": {
+        "id": "WFF7Xp2lLILA"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "version_instructions = instructions['v2'] #v2 : prompt séparé en reformulation et traitement de la réponse\n",
+        "LLM = {\n",
+        "    'llm_model_family' : 'mistral', #albert #mistral #chatgpt\n",
+        "    'llm_model_version' : 'mistral-large-2407' #gpt-3.5-turbo #mistral-large-2407 #meta-llama/Meta-Llama-3.1-70B-Instruct\n",
+        "    } #choix du modèl de LLM (la reformulation, et la réponse)\n",
+        "\n",
+        "top_K = 2 #nombre de chunks en sortie de chaque query\n",
+        "\n",
+        "question_utilisateur = \"\"\" un salarié a droit à combien de semains de congés par an ? merci\"\"\"\n",
+        "# pour trouver des questions types : https://docs.google.com/spreadsheets/d/1bvss8wGC6UiaCyp4dvyBDt7mgdk-nyecf6epIdvfGm4/edit?gid=1360931749#gid=1360931749\n"
+      ],
+      "metadata": {
+        "id": "z-KKpumpLL1O"
+      },
+      "execution_count": 27,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Lancement d'un test pour une question"
+      ],
+      "metadata": {
+        "id": "UzkSub9FMB46"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "reponse_assistant = pipeline_test_RAG(version_instructions, LLM, question_utilisateur, top_K)"
+      ],
+      "metadata": {
+        "id": "f3XivpCAMGI5"
+      },
+      "execution_count": 28,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "reponse_assistant['reponse_assistant'] # la réponse de l'assistant"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 214
+        },
+        "id": "Wb3MOBK6XcWz",
+        "outputId": "f65c5d84-91e2-429e-e2e4-4883d008a2d7"
+      },
+      "execution_count": 29,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "\"### Reformulation de la demande\\n\\n**Contexte :**\\nVous êtes un salarié en France et vous souhaitez connaître le nombre de semaines de congés payés auxquelles vous avez droit par an. Vous vous interrogez également sur les conditions spécifiques pour bénéficier de ces congés.\\n\\n**Points juridiques à traiter :**\\n1. Combien de semaines de congés payés un salarié a-t-il droit par an en France ?\\n2. Y a-t-il des conditions spécifiques à remplir pour bénéficier de ces congés ?\\n\\n### Réponse\\n\\n#### 1. Combien de semaines de congés payés un salarié a-t-il droit par an en France ?\\n\\n**Principe général de droit :**\\nEn France, tout salarié a droit à des congés payés. La durée légale des congés payés est de 2,5 jours ouvrables par mois de travail effectif.\\n\\n**Détail :**\\nPour une année complète de travail, cela équivaut à 30 jours ouvrables de congés payés, soit environ 5 semaines.\\n\\n**Source :**\\nTitre du document : Salariés détachés : vos droits\\nConformément au droit français, tout salarié détaché bénéficie d'un droit à congés payés, soit 2,5 jours par mois effectif de travail. Pour une période d'activité inférieure à un mois, le droit à congé est proratisé selon la règle suivante : nombre de jours travaillés / 26 jours par mois (travail sur 6 jours dans la semaine, soit 52 semaines / 12 mois * 6 jours = 26 jours).\\n\\n#### 2. Y a-t-il des conditions spécifiques à remplir pour bénéficier de ces congés ?\\n\\n**Principe général de droit :**\\nLes congés payés sont un droit pour tous les salariés, mais il existe certaines conditions spécifiques à remplir pour en bénéficier.\\n\\n**Détail :**\\nLes congés payés sont acquis proportionnellement au temps de travail effectif. Si vous travaillez moins d'un mois complet, le nombre de jours de congés payés est proratisé.\\n\\n**Source :**\\nTitre du document : Salariés détachés : vos droits\\nConformément au droit français, tout salarié détaché bénéficie d'un droit à congés payés, soit 2,5 jours par mois effectif de travail. Pour une période d'activité inférieure à un mois, le droit à congé est proratisé selon la règle suivante : nombre de jours travaillés / 26 jours par mois (travail sur 6 jours dans la semaine, soit 52 semaines / 12 mois * 6 jours = 26 jours).\\n\\n### Conclusion\\n\\nEn France, un salarié a droit à 5 semaines de congés payés par an, soit 30 jours ouvrables. Ces congés sont acquis proportionnellement au temps de travail effectif. Pour bénéficier de ces congés, il est important de connaître les conditions spécifiques liées à la durée de travail effectif.\\n\\n### Prochaines étapes\\n\\nPour compléter cette réponse, avez-vous des questions supplémentaires concernant les modalités de prise de congés ou les éventuelles conditions spécifiques à votre situation (par exemple, si vous travaillez à temps partiel ou si vous avez des périodes d'absence) ?\""
+            ],
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "string"
+            }
+          },
+          "metadata": {},
+          "execution_count": 29
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "reponse_assistant['urls'] # la sources sélectionnées en sortie du RAG"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "khL6PFQdaDl6",
+        "outputId": "951185e0-f9fa-4d1c-ea94-135bf95a6f38"
+      },
+      "execution_count": 30,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "['https://code.travail.gouv.fr/fiche-ministere-travail/salaries-detaches-vos-droits',\n",
+              " 'https://code.travail.gouv.fr/fiche-service-public/labsence-du-salarie-est-elle-prise-en-compte-pour-le-calcul-de-ses-conges',\n",
+              " 'https://code.travail.gouv.fr/fiche-service-public/conge-de-formation-economique-sociale-environnementale-et-syndicale-cfeses',\n",
+              " 'https://code.travail.gouv.fr/fiche-service-public/conge-de-proche-aidant']"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 30
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "reponse_assistant['question_reformulee'] # la question reformulée"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 89
+        },
+        "id": "9xNloWibaIwd",
+        "outputId": "73bab9db-404b-48e3-e7f3-35f70ea7c03d"
+      },
+      "execution_count": 31,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "\"Bonjour,\\n\\nJe suis salarié et je souhaite savoir combien de semaines de congés payés j'ai droit par an.\\n\\nMes questions sont :\\n- Combien de semaines de congés payés un salarié a-t-il droit par an en France ?\\n- Y a-t-il des conditions spécifiques à remplir pour bénéficier de ces congés ?\\n\\nMerci.\""
+            ],
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "string"
+            }
+          },
+          "metadata": {},
+          "execution_count": 31
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "ov35es4wkvjA"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}

--- a/srdt_analysis/framework_test_functions.py
+++ b/srdt_analysis/framework_test_functions.py
@@ -1,0 +1,134 @@
+from mistralai import Mistral
+import openai
+from openai import OpenAI
+from instructions_LLM import instructions
+from functions_pipeline_rag_test import all
+import json
+import requests
+from API_KEYS import keys
+
+def call_LLM(user_prompt: str, instructions_prompt: str, LLM_model_family: str, LLM_model_version: str,) -> str:
+    """
+    Appelle l'API OpenAI pour interagir avec un modèle GPT (par exemple GPT-4).
+
+    :param question_utilisateur: La question ou le contexte de l'utilisateur.
+    :param instructions_prompt: Les instructions spécifiques à fournir au modèle.    
+    :param LLM_model_family: entre chatgpr, mistral et albert.
+    :param LLM_model_version: la version de tests de l'asistant juridique global'.    
+    :return: La réponse générée par le modèle sous forme de texte.
+    """
+    api_key = keys[LLM_model_family.upper() + "_KEY"]
+    data = {"model" : LLM_model_version,  
+            'messages' : [
+                {"role": "system", "content": instructions_prompt},
+                {"role": "user", "content": question_utilisateur}
+            ]}
+
+
+    # Appel de la bonne api (3 choix possibles)        
+
+    if LLM_model_family == 'chatgpt':
+
+        openai.api_key = api_key
+        # Appel de l'API
+        response = openai.chat.completions.create(**data)       
+
+
+    elif LLM_model_family == 'mistral':
+
+        client = Mistral(api_key=api_key)            
+        response = client.chat.complete(**data)       
+
+    elif LLM_model_family == 'albert':
+
+        base_url = "https://albert.api.etalab.gouv.fr/v1"
+        client = OpenAI(base_url=base_url, api_key=api_key)
+        response = client.chat.completions.create(**data)
+
+    # Extraction de la réponse du modèle
+    return response.choices[0].message.content.strip()
+
+
+
+def albert_search(collections: list, query: str, k: int) -> list:
+    """  
+    :return: le top K des chunks en résultat du search Albert sur la query : contenu du chunk, titre du document, url du document
+    """
+    base_url = "https://albert.api.etalab.gouv.fr/v1"
+    api_key = ALBERT_KEY
+    data = {'collections':collections,
+        'k':k,
+        'prompt':query}
+    session = requests.session()
+    session.headers = {"Authorization": f"Bearer {api_key}"}
+    response = session.post(url=f"{base_url}/search", json=data, headers={"Authorization": f"Bearer {api_key}"})
+
+    return response.json()["data"]
+
+
+def pipeline_test_RAG(instructions, LLM, question_utilisateur):
+    """
+    :return: retourne la réponse de l'assistant, la liste des url sources, et les id des documents sources, et la question reformulée
+    """
+    # 1ère étape : anonymiser avec Albert
+    anonymized_question = call_LLM(user_prompt=question_utilisateur, 
+        instructions_prompt=instructions['anonymisation'],
+        LLM_model_family='albert',
+        LLM_model_version='meta-llama/Meta-Llama-3.1-70B-Instruct'
+        )
+
+    # 2ème étape : reformuler la question
+    rephrased_question = call_LLM(user_prompt=anonymized_question, 
+        instructions_prompt=instructions['reformulation'],
+        LLM_model_family=LLM['llm_model_family'],
+        LLM_model_version=LLM['llm_model_version']
+        )
+
+    # 3ème étape : séparer la question en multiple queries
+    multiple_queries = call_LLM(user_prompt=rephrased_question, 
+        instructions_prompt=instructions['split_multiple_queries'],
+        LLM_model_family=LLM['llm_model_family'],
+        LLM_model_version=LLM['llm_model_version']
+        )
+    multiple_queries = json.loads(multiple_queries)
+
+
+    # 4ème étape : aller chercher le top K des chunks par query dans les collections Albert
+    top_chunks = list()
+    for _i in range(len(multiple_queries.keys())):
+        _query = multiple_queries[list(multiple_queries.keys())[_i]]
+        top_chunks = top_chunks + albert_search(collections=collections_albert, query=_query, k=top_K)
+
+
+    # 5ème étape : rajouter les chunks à l'instruction
+    final_instruction = instructions['final_instruction']
+    sources_id = list()
+    sources_url = list()
+    sources_contenu = dict()
+
+    for _i in range(len(top_chunks)):
+        if top_chunks[_i]['chunk']['metadata']['document_id'] not in sources_id : sources_id.append(top_chunks[_i]['chunk']['metadata']['document_id'])
+        if top_chunks[_i]['chunk']['metadata']['url'] not in sources_url : sources_url.append(top_chunks[_i]['chunk']['metadata']['url'])
+        if top_chunks[_i]['chunk']['metadata']['document_name'] not in sources_contenu.keys() :
+            sources_contenu[top_chunks[_i]['chunk']['metadata']['document_name']] = list()
+            sources_contenu[top_chunks[_i]['chunk']['metadata']['document_name']].append(top_chunks[_i]['chunk']['content'])
+
+    for _j in range(len(sources_contenu.keys())):
+        _titre = list(sources_contenu.keys())[_j]
+        _chunk =  "\n ### Titre du document : " + _titre + "\n"
+        for _k in range(len(sources_contenu[_titre])):
+            _extrait = sources_contenu[_titre][_k]
+            _chunk = _chunk + "\n\n" + _extrait +  "\n\n"
+        final_instruction = final_instruction + _chunk
+
+    # 6ème étape : appeler le LLM pour obtenir la réponse
+    reponse_assistant = call_LLM(user_prompt=rephrased_question, 
+        instructions_prompt=final_instruction, 
+        LLM_model_family=LLM['llm_model_family'],
+        LLM_model_version=LLM['llm_model_version'])
+
+    return {'reponse_assistant' : reponse_assistant,
+            'urls' : sources_url,
+            'documents_id' : sources_id
+            'question_reformulee' : rephrased_question
+            }

--- a/srdt_analysis/framework_test_functions.py
+++ b/srdt_analysis/framework_test_functions.py
@@ -129,6 +129,6 @@ def pipeline_test_RAG(instructions, LLM, question_utilisateur):
 
     return {'reponse_assistant' : reponse_assistant,
             'urls' : sources_url,
-            'documents_id' : sources_id
+            'documents_id' : sources_id,
             'question_reformulee' : rephrased_question
             }

--- a/srdt_analysis/instructions_LLM.py
+++ b/srdt_analysis/instructions_LLM.py
@@ -1,0 +1,120 @@
+versioning_instructions = {'v2' : 
+	{"anonymisation" : """
+	# Instructions
+
+	Anonymise le texte suivant en remplaçant toutes les informations personnelles par des balises standard, sauf le titre de poste et la civilité, qui doivent rester inchangés. Utilise [PERSONNE] pour les noms de personnes, [EMAIL] pour les adresses email, [TELEPHONE] pour les numéros de téléphone, [ADRESSE] pour les adresses physiques, [DATE] pour les dates, et [IDENTIFIANT] pour tout identifiant unique ou sensible.
+
+	# Exemple 
+
+	- Texte :
+	"Bonjour, je suis employé chez ABC Construction à Lyon en tant que chef de chantier. Mon responsable, M. Dupont, m’a demandé de travailler deux week-ends consécutifs. J’aimerais savoir si c’est légal, car il n’a pas mentionné de rémunération supplémentaire. Mon numéro de salarié est 123456. Pouvez-vous me renseigner sur mes droits concernant les jours de repos et les heures supplémentaires ? Merci."
+
+	- Texte anonymisé :
+	Bonjour, je suis employé chez [ENTREPRISE] en tant que chef de chantier. Mon responsable, [PERSONNE], m’a demandé de travailler deux week-ends consécutifs. J’aimerais savoir si c’est légal, car il n’a pas mentionné de rémunération supplémentaire. Mon numéro de salarié est [IDENTIFIANT]. Pouvez-vous me renseigner sur mes droits concernant les jours de repos et les heures supplémentaires ? Merci.
+	""" , 
+
+	"reformulation" : """
+	# Instructions
+
+	## Objectif
+
+	L'assistant juridique a pour mission de reformuler des questions juridiques relatives au droit du travail posées par les salariés ou employeurs du secteur privé en France. L’objectif est de reformuler la question d'origine de façon claire sans perdre les détails, et de mettre en avant les points juridiques pour qu'un agent public puisse y répondre plus efficacement. Attention, dans la reformulation, c'est l'usager qui est à la première personne et non l'assistant (comme c'est le cas dans l'exemple plus bas).
+
+	## Etape 
+	- Identification des points juridiques : Repérer tous les points qui demandent une réponse juridique dans la question de l'utilisateur. Ne pas hésiter à anticiper et mentionner des questions juridiques à laquelle l’utilisateur n’aurait pas pensé.
+
+	- Reformulation claire et structurée : Formuler la question en deux parties : 
+	Un paragraphe de contexte dans laquelle la personne raconte sa situation 
+	Une synthèse des questions juridiques que soulève la personne. Cette synthèse reprend donc l’ensemble des points juridiques identifiés.
+
+	- Exemple
+	Question initiale :
+	"Bonjour, 
+	J’ai effectuée un remplacement en CDD dans une micro crèche, mon contrat étant fini depuis le 22 septembre 2023 je suis toujours en attente de mon salaire. Après plusieurs relance auprès de la directrice aucun versement n’a été fait. J’aimerais savoir si elle est en droit de me faire patienter comme cela ou sinon qu’elle sont les délais pour qu’elle puisse me verser mon salaire. 
+	Cordialement."
+
+	Reformulation attendue :
+	"Bonjour, 
+	J’ai effectuée un remplacement en CDD dans une micro crèche, mon contrat étant fini depuis le 22 septembre 2023 je suis toujours en attente de mon salaire. Après plusieurs relance auprès de la directrice aucun versement n’a été fait. 
+
+	Mes questions sont : 
+	La directrice est-elle en droit de retarder le paiement de mon salaire ?
+	Quels sont les délais légaux pour qu’un employeur verse le salaire d’un employé à la fin d’un CDD ? 
+	Quels sont les recours applicables et la procédure à suivre ? 
+	Cordialement."
+	""",
+
+	"split_multiple_queries" : """
+	## Objectif
+	Tu es chargé d'identifier toutes les questions qui ont été posées dans la fenêtre de chat, et de les renvoyer sous format d'un document json
+
+	## Etape
+	- tu identifies toutes les questions qui sont formulées dans la fenêtre de chat
+	- tu les enregistres dans des variables (sans changer un mot) "question_i" où
+	i est le numéro de la question, et i va de 1 à N s'il y a N questions identifiées
+
+	## Format de sortie
+	Format de json attendu en sortie (pour 2 questions)
+	{
+	    "question_1": texte_question_1,
+	    "question_2": texte_question_2,
+	}
+
+	## Point d'attention
+	Je veux que la réponse que tu fais soit directement réutilisable dans un programme de code. Aussi je ne veux aucun caractère supplémentaire de type "/n", je veux seulement le json en sortie et absolument rien d'autre.
+
+
+	## Exemple
+	- texte de la fenêtre de chat : "Bonjour, 
+
+	Actuellement membre du CSE, de la CSSCT et de la RPX, ma direction souhaite me changer de roulement à compter de janvier. Lors de notre première rencontre non officielle, il a été dit que mes absences mettaient mes collègues en souffrance en raison du grand nombre de remplaçants et qu'il fallait séparer un binôme sur l'équipe inverse. Lors d'une seconde rencontre non officielle, ma direction m'a indiqué qu'ils n'avaient rien à reprocher à mon travail, mais qu'il fallait redynamiser un peu et continuer à séparer le binôme sur les deux équipes.
+
+	Je travaille en roulement amplitude de 12h, avec 10h travaillées et 2h de pause. Un week-end sur 2, et si elle me change de roulement, je travaillerais complètement à l'inverse de mon roulement actuel, ce qui rendrait impossible pour moi d'assurer la garde de mon enfant. Par conséquent, je risque de ne plus pouvoir venir travailler.
+
+	Ma direction souhaite effectuer ce changement début janvier, mais à ce jour, je n'ai reçu qu'une information officieuse, aucun entretien officiel ou courrier ne m'a été adressé.
+
+	Mes questions sont : 
+	En tant que salariée protégée (membre du CSE, de la CSSCT et de la RPX), ma direction a-t-elle le droit de modifier mon roulement de travail ? 
+	Quelles sont mes recours et la procédure à suivre si je considère que ce changement n'est pas légitime et impacte ma vie familiale ? 
+
+	Je souhaite obtenir ces informations afin de les lui expliquer, avant d'envisager des démarches plus formelles auprès des services compétents.
+
+	Merci d'avance pour votre retour."
+
+	- réponse attendue :
+	{"question_1" : "En tant que salariée protégée (membre du CSE, de la CSSCT et de la RPX), ma direction a-t-elle le droit de modifier mon roulement de travail ?",
+	"question_2" : "Quelles sont mes recours et la procédure à suivre si je considère que ce changement n'est pas légitime et impacte ma vie familiale ?"
+	}
+	""",
+
+	"final_instruction" : """
+	# Instructions
+
+	## Rôle et objectif
+	L'assistant juridique est conçu pour répondre aux questions des usagers (salariés et employeurs du secteur privé) en France concernant le droit du travail, conformément aux normes et règlements du droit français. L'objectif est de fournir des informations juridiques précises et contextualisées, en utilisant des extraits de documents pertinents pour soutenir chaque réponse.
+
+	## Lignes directrices
+	A chaque fois que l'utilisateur sollicite l'assistant juridique, le chatbot va procéder ainsi :
+
+	- Reformuler la demande de l’utilisateur en deux parties : le contexte, et les points juridiques à traiter. Puis y répondre.
+
+	- Pour chaque point, citer la source juridique utilisée dans la base de connaissance externe (qui se trouve ci-dessous), ou bien citer le passage correspondant. Commencer par citer le principe général de droit qui répond au point, puis aller dans le détail en distinguant les cas particuliers, ou en posant des questions à l'utilisateur pour avoir plus de précisions quand cela est nécessaire
+
+	- Conclure en synthétisant la réponse et si nécessaire, en indiquant les prochaines étapes à suivre, ainsi qu’en posant des questions qui vont permettre de compléter la réponse 
+
+	## Limites et contraintes
+	Il faut faire attention à ce que toutes les réponses aient une question. Mais si une question n'a pas de réponse, il ne faut pas inventer et plutôt simplement indiquer que la réponse n'a pas été trouvée. Si tu as besoin d’informations supplémentaires pour répondre à une question, tu demandes simplement ces informations à l’usager qui te les donnera. 
+
+	## Style et ton.
+	Répondre dans un langage clair et accessible.
+
+	## Base de connaissance externe.
+	Voici les extraits de documents que tu peux utiliser, avec cette structure : titre du document, contenu du document, url_source.
+
+	"""
+	}
+}
+
+
+
+


### PR DESCRIPTION
- Le notebook importe les fonctions dans "framework_test_functions.py" et les instructions contenues dans 'instructions_LLM.py' (qui historise les versions de prompt) 

- 3 paramètres de test  sont possible sur ce notebook  : le "top_K" de chunks récupérées en sortie de chaque queries, le choix du prompt (mistral/albert/chatgpt), et la version des instructions.

Pour la suite, il faut : 
- rajouter des paramètres de tests. En priorité, la possibilité d'ingérer le texte complet VS seulement le chunk aujourd'hui dans le prompt. 
- obtenir des scores de performance en approximant la précision / le recall, en comparant aux réponses types attendues dans la base de 20 questions annotées