### PR TITLE
chore: autoriser seulement yarn comme packagemanager pour ne pas s'embrouiller

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -33,5 +33,11 @@
     "eslint-config-next": "15.1.4",
     "sass": "^1.83.4",
     "typescript": "^5"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "yarn",
+      "onFail": "error"
+    }
   }
 }


### PR DESCRIPTION
fix #152 