### PR TITLE
feat: add charon for dev branches

### DIFF
--- a/.kontinuous/env/dev/templates/web.configmap.yaml
+++ b/.kontinuous/env/dev/templates/web.configmap.yaml
@@ -6,6 +6,8 @@ data:
   CHATGPT_MODEL_NAME: gpt-4o-2024-11-20
   MISTRAL_MODEL_NAME: mistral-large-latest
   ALBERT_MODEL_NAME: albert-large
-  NEXTAUTH_URL: https://web-srdt-preprod.ovh.fabrique.social.gouv.fr
+  NEXTAUTH_URL: https://web-{{ .Values.global.host }}
   PROCONNECT_ENV: integration
   NEXT_PUBLIC_PROCONNECT_ENV: integration
+  CHARON_URL: https://srdt-charon.ovh.fabrique.social.gouv.fr
+  NEXT_PUBLIC_CHARON_URL: https://srdt-charon.ovh.fabrique.social.gouv.fr

--- a/web/src/lib/auth/ProConnectProvider.ts
+++ b/web/src/lib/auth/ProConnectProvider.ts
@@ -36,7 +36,7 @@ export default function ProConnectProvider<P extends ProConnectProfile>(
   // to allow dynamic branch URLs without registering each one in ProConnect.
   // Charon rewrites authorization/token endpoints but keeps userinfo/jwks direct.
   const wellKnownUrl = process.env.CHARON_URL
-    ? `${process.env.CHARON_URL}/moncompteprotest/.well-known/openid-configuration`
+    ? `${process.env.CHARON_URL}/proconnecttest/.well-known/openid-configuration`
     : `${PROCONNECT_DOMAIN}/.well-known/openid-configuration`;
 
   return {

--- a/web/src/lib/auth/ProConnectProvider.ts
+++ b/web/src/lib/auth/ProConnectProvider.ts
@@ -36,7 +36,7 @@ export default function ProConnectProvider<P extends ProConnectProfile>(
   // to allow dynamic branch URLs without registering each one in ProConnect.
   // Charon rewrites authorization/token endpoints but keeps userinfo/jwks direct.
   const wellKnownUrl = process.env.CHARON_URL
-    ? `${process.env.CHARON_URL}/proconnect/.well-known/openid-configuration`
+    ? `${process.env.CHARON_URL}/moncompteprotest/.well-known/openid-configuration`
     : `${PROCONNECT_DOMAIN}/.well-known/openid-configuration`;
 
   return {

--- a/web/src/lib/auth/ProConnectProvider.ts
+++ b/web/src/lib/auth/ProConnectProvider.ts
@@ -32,11 +32,18 @@ export default function ProConnectProvider<P extends ProConnectProfile>(
       ? "https://auth.agentconnect.gouv.fr/api/v2"
       : "https://fca.integ01.dev-agentconnect.fr/api/v2";
 
+  // When CHARON_URL is set (dev branches), route OAuth discovery through Charon proxy
+  // to allow dynamic branch URLs without registering each one in ProConnect.
+  // Charon rewrites authorization/token endpoints but keeps userinfo/jwks direct.
+  const wellKnownUrl = process.env.CHARON_URL
+    ? `${process.env.CHARON_URL}/proconnect/.well-known/openid-configuration`
+    : `${PROCONNECT_DOMAIN}/.well-known/openid-configuration`;
+
   return {
     id: "proconnect",
     name: "ProConnect",
     type: "oauth",
-    wellKnown: `${PROCONNECT_DOMAIN}/.well-known/openid-configuration`,
+    wellKnown: wellKnownUrl,
     authorization: {
       params: {
         // ProConnect requires individual scopes for each claim

--- a/web/src/lib/auth/proconnect-logout.ts
+++ b/web/src/lib/auth/proconnect-logout.ts
@@ -9,7 +9,7 @@
 export function getProConnectLogoutUrl(): string {
   // When CHARON_URL is set (dev branches), route logout through Charon proxy
   if (process.env.NEXT_PUBLIC_CHARON_URL) {
-    return `${process.env.NEXT_PUBLIC_CHARON_URL}/moncompteprotest/oauth/logout`;
+    return `${process.env.NEXT_PUBLIC_CHARON_URL}/proconnecttest/oauth/logout`;
   }
 
   const PROCONNECT_DOMAIN =

--- a/web/src/lib/auth/proconnect-logout.ts
+++ b/web/src/lib/auth/proconnect-logout.ts
@@ -7,11 +7,15 @@
  * Get the ProConnect end_session_endpoint URL based on environment
  */
 export function getProConnectLogoutUrl(): string {
+  // When CHARON_URL is set (dev branches), route logout through Charon proxy
+  if (process.env.NEXT_PUBLIC_CHARON_URL) {
+    return `${process.env.NEXT_PUBLIC_CHARON_URL}/proconnect/session/end`;
+  }
+
   const PROCONNECT_DOMAIN =
     process.env.NEXT_PUBLIC_PROCONNECT_ENV === "integration"
       ? "https://fca.integ01.dev-agentconnect.fr/api/v2"
       : "https://auth.agentconnect.gouv.fr/api/v2";
-
 
   // OpenID Connect standard logout endpoint
   return `${PROCONNECT_DOMAIN}/session/end`;

--- a/web/src/lib/auth/proconnect-logout.ts
+++ b/web/src/lib/auth/proconnect-logout.ts
@@ -9,7 +9,7 @@
 export function getProConnectLogoutUrl(): string {
   // When CHARON_URL is set (dev branches), route logout through Charon proxy
   if (process.env.NEXT_PUBLIC_CHARON_URL) {
-    return `${process.env.NEXT_PUBLIC_CHARON_URL}/proconnect/session/end`;
+    return `${process.env.NEXT_PUBLIC_CHARON_URL}/moncompteprotest/oauth/logout`;
   }
 
   const PROCONNECT_DOMAIN =


### PR DESCRIPTION
- [x] Confirmer avec l'équipe SRE que l'instance Charon est bien active sur srdt-charon.ovh.fabrique.social.gouv.fr et que le provider proconnect existe
- [ ] Ajouter l'URL de callback de Charon dans ProConnect intégration : https://srdt-charon.ovh.fabrique.social.gouv.fr/oauth/callback