### PR TITLE
ci: migrate image builds from buildkit-service to buildkit-operator

### DIFF
--- a/.github/workflows/preproduction.yaml
+++ b/.github/workflows/preproduction.yaml
@@ -11,6 +11,9 @@ concurrency:
 
 jobs:
   build-api:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-preproduction
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -28,23 +31,30 @@ jobs:
             type=sha,prefix=preprod-,format=long,priority=850
             type=sha,prefix=sha-,format=long,priority=890
 
-      - name: 📦 Build and push Docker image for api
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for api
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "api"
-          dockerfile: "Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
+          push: true
 
   build-web:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-preproduction
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -62,23 +72,27 @@ jobs:
             type=sha,prefix=preprod-,format=long,priority=850
             type=sha,prefix=sha-,format=long,priority=890
 
-      - name: 📦 Build and push Docker image for web
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for web
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "web"
-          dockerfile: "Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
           build-args: |
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+          push: true
 
   kontinuous:
     needs: [build-api, build-web]

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -11,6 +11,9 @@ concurrency:
 
 jobs:
   build-api:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-production
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -29,23 +32,30 @@ jobs:
             type=sha,prefix=sha-,format=long,priority=890
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }},priority=200
 
-      - name: 📦 Build and push Docker image for api
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for api
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "api"
-          dockerfile: "Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
+          push: true
 
   build-web:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-production
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -64,23 +74,27 @@ jobs:
             type=sha,prefix=sha-,format=long,priority=890
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }},priority=200
 
-      - name: 📦 Build and push Docker image for web
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for web
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "web"
-          dockerfile: "Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
           build-args: |
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+          push: true
 
   kontinuous:
     needs: [build-api, build-web]

--- a/.github/workflows/review-auto.yaml
+++ b/.github/workflows/review-auto.yaml
@@ -13,6 +13,9 @@ concurrency:
 
 jobs:
   build-api:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-review-auto
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -41,23 +44,30 @@ jobs:
         id: env
         uses: socialgouv/kontinuous/.github/actions/env@v1
 
-      - name: 📦 Build and push Docker image for api
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for api
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "api"
-          dockerfile: "Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
+          push: true
 
   build-web:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-review-auto
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -86,23 +96,27 @@ jobs:
         id: env
         uses: socialgouv/kontinuous/.github/actions/env@v1
 
-      - name: 📦 Build and push Docker image for web
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for web
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "web"
-          dockerfile: "Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
           build-args: |
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+          push: true
 
   kontinuous:
     needs: [build-api, build-web]

--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -11,6 +11,9 @@ concurrency:
 
 jobs:
   build-api:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-review
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -39,23 +42,30 @@ jobs:
         id: env
         uses: socialgouv/kontinuous/.github/actions/env@v1
 
-      - name: 📦 Build and push Docker image for api
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for api
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "api"
-          dockerfile: "Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
+          push: true
 
   build-web:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-review
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -84,23 +94,27 @@ jobs:
         id: env
         uses: socialgouv/kontinuous/.github/actions/env@v1
 
-      - name: 📦 Build and push Docker image for web
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for web
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "web"
-          dockerfile: "Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
           build-args: |
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+          push: true
 
   kontinuous:
     needs: [build-api, build-web]


### PR DESCRIPTION
Migre les builds d'images CI du service legacy **buildkit-service** (`socialgouv/workflows/actions/buildkit@v1`, `buildctl` sur le runner) vers **[buildkit-operator](https://github.com/SocialGouv/buildkit-operator)** (`socialgouv/buildkit-operator@v1`) : chaque build est routé vers le buildkitd chaud dédié au repo (cache par projet, plus de consistent-hash sur 6 daemons partagés).

**12 repos SocialGouv déjà migrés et en production sur ce modèle** (revu, da-manager, jardinmental, enfants-du-spectacle, famille 1000jours…) — builds et deploys validés de bout en bout.

## Mapping

- `socialgouv/workflows/actions/buildkit@v1` → `socialgouv/buildkit-operator@v1` (`dockerfile:` → `file:`, `push: true` explicite ; `build-args`, `secrets`, `target` inchangés).
- Auth `/route` : GitHub OIDC (`permissions.id-token: write` sur le job de build) — identité du repo vérifiée côté serveur, aucun token partagé.
- Secrets/vars org-level (`BUILDKIT_OPERATOR_CA/CERT/KEY`, `BUILDKIT_OPERATOR_BUILDD_URL`, `BUILDKIT_OPERATOR_GATEWAY_HOST`) → zéro setup côté repo.
- Login registry : `docker/login-action@v4` (auth forwardée au daemon via la session buildx) — remplace les inputs `registry*` de l'action legacy.
- Supprimés (sans objet) : `buildkit-daemon-address`, `buildkit-svc-count`, `buildkit-cert-*`, `cache-*` (le cache vit dans le daemon du projet), `fallback-enabled`.

## Validation & merge

Le build a été validé sur cette branche (voir checks/runs). **Le merge revient à l'équipe** — buildkit-service reste en service pendant toute la migration, le rollback est un simple revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
